### PR TITLE
Feature/improvement active child scroll

### DIFF
--- a/src/hooks/useActiveChildScroll.ts
+++ b/src/hooks/useActiveChildScroll.ts
@@ -5,19 +5,21 @@ interface UseActiveItemScrollProps<P> {
   parentRef: React.Ref<P>;
 }
 
+const isRefObject = <T>(ref: React.Ref<T>): ref is React.RefObject<T> =>
+  ref !== null && typeof ref !== 'function';
+
 const useActiveChildScroll = <P extends HTMLElement, C extends HTMLElement>({
   activeId,
   parentRef,
 }: UseActiveItemScrollProps<P>) => {
   const itemRefs = useRef<Record<string, C | null>>({});
 
-  const isRefObject =
-    parentRef && typeof parentRef !== 'function' && parentRef.current;
-
   const activeChildNode = activeId ? itemRefs.current[activeId] : null;
 
   useEffect(() => {
-    if (!isRefObject || !activeId || !activeChildNode) return;
+    if (!isRefObject(parentRef) || !parentRef.current || !activeChildNode) {
+      return;
+    }
 
     const getScrollPosition = () => {
       const { offsetTop, offsetLeft, offsetHeight, offsetWidth, offsetParent } =

--- a/src/hooks/useActiveChildScroll.ts
+++ b/src/hooks/useActiveChildScroll.ts
@@ -14,20 +14,31 @@ const useActiveChildScroll = <P extends HTMLElement, C extends HTMLElement>({
   const isRefObject =
     parentRef && typeof parentRef !== 'function' && parentRef.current;
 
+  const activeChildNode = activeId ? itemRefs.current[activeId] : null;
+
   useEffect(() => {
-    if (!isRefObject || !activeId) return;
+    if (!isRefObject || !activeId || !activeChildNode) return;
 
-    const activeItem = itemRefs.current[activeId];
+    const getScrollPosition = () => {
+      const { offsetTop, offsetLeft, offsetHeight, offsetWidth, offsetParent } =
+        activeChildNode;
 
-    if (!activeItem) return;
+      if (!offsetParent) return { top: 0, left: 0 };
 
-    const { offsetTop, offsetLeft, offsetHeight, offsetWidth } = activeItem;
+      const remainingHeight = offsetParent.clientHeight - offsetHeight;
+      const remainingWidth = offsetParent.clientWidth - offsetWidth;
+      const topForCenterScroll = offsetTop - remainingHeight / 2;
+      const leftForCenterScroll = offsetLeft - remainingWidth / 2;
 
-    parentRef.current.scrollTo({
-      top: offsetTop - offsetHeight,
-      left: offsetLeft - offsetWidth,
-      behavior: 'smooth',
-    });
+      return {
+        top: topForCenterScroll,
+        left: leftForCenterScroll,
+      };
+    };
+
+    const { top, left } = getScrollPosition();
+
+    parentRef.current.scrollTo({ top, left, behavior: 'smooth' });
   }, [activeId]);
 
   const registerChildRef = useCallback(


### PR DESCRIPTION
## 변경사항
- `useActiveChildScroll` 훅 개선
  - 자식 요소가 active 되면 부모의 중앙에 위치하게끔 스크롤 위치 수정