### PR TITLE
Fix `useDetectScroll` hook's rendering issue

### DIFF
--- a/src/hooks/useDetectScroll.ts
+++ b/src/hooks/useDetectScroll.ts
@@ -1,8 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useRouter } from 'next/router';
 
-import { useAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 
 import scrollAtom from '../atoms/scrollAtom';
 import { ScrollDirection } from '../constants';
@@ -11,8 +11,8 @@ import useThrottle from './useThrottle';
 const THROTTLE_TIME_MS = 100;
 
 const useDetectScroll = () => {
-  const [scroll, setScroll] = useAtom(scrollAtom);
-  const { pageY } = scroll;
+  const setScroll = useSetAtom(scrollAtom);
+  const pageYRef = useRef(0);
 
   const router = useRouter();
 
@@ -31,17 +31,18 @@ const useDetectScroll = () => {
   const handleScroll = useThrottle(() => {
     const { scrollY } = window;
 
-    const deltaY = scrollY - pageY;
+    const deltaY = scrollY - pageYRef.current;
     const isScrollUp = scrollY === 0 || deltaY < 0;
     const direction = isScrollUp ? ScrollDirection.up : ScrollDirection.down;
 
+    pageYRef.current = scrollY;
     setScroll({ direction, pageY: scrollY, isRouting: false });
   }, THROTTLE_TIME_MS);
 
   useEffect(() => {
     document.addEventListener('scroll', handleScroll);
     return () => document.removeEventListener('scroll', handleScroll);
-  }, [handleScroll, pageY]);
+  }, [handleScroll]);
 };
 
 export default useDetectScroll;


### PR DESCRIPTION
## 변경사항
- `useDetectScroll` hook의 렌더링 이슈 해결 Closes #141
  - `useAtom`을 `useSetAtom`으로 변경
  - 이전 스크롤 위치 상태를 저장하기 위해서 `pageYRef` 변수 생성