### PR TITLE
포스트 리스트 프리뷰 텍스트 일부 수정

### DIFF
--- a/src/lib/posts/post.ts
+++ b/src/lib/posts/post.ts
@@ -82,12 +82,6 @@ const getPostMarkdownFilePaths = () => {
 };
 
 const getPostPreview = (fileName: string): PostPreview => {
-  const POST_PREVIEW_BEFORE_REMOVED_MAX_LENGTH = 500;
-  const POST_PREVIEW_CONTENT_MAX_LENGTH = 200;
-  const MARKDOWN_CODE_BLOCK_REG_EXP_1 = RegExp(/```([\s\S]*?)```/g);
-  const MARKDOWN_CODE_BLOCK_REG_EXP_2 = RegExp(/~~~([\s\S]*?)~~~/g);
-  const MARKDOWN_HEADING_REG_EXP = RegExp(/#{1,6}.+(?=\n)/);
-
   const id = fileName.replace(/\.md$/, '');
 
   const fullPath = path.join(POST_DIRECTORY, fileName);
@@ -97,28 +91,36 @@ const getPostPreview = (fileName: string): PostPreview => {
 
   const {
     data: { date, title, tag },
-    content: fullContent,
+    content,
   } = matterResult;
-
-  const preProcessedContent = fullContent
-    .slice(0, POST_PREVIEW_BEFORE_REMOVED_MAX_LENGTH)
-    .replace(MARKDOWN_HEADING_REG_EXP, '')
-    .replace(MARKDOWN_CODE_BLOCK_REG_EXP_1, '')
-    .replace(MARKDOWN_CODE_BLOCK_REG_EXP_2, '');
-
-  let content = removeMarkdown(preProcessedContent, {
-    useImgAltText: false,
-  }).slice(0, POST_PREVIEW_CONTENT_MAX_LENGTH);
-
-  if (content.length >= POST_PREVIEW_CONTENT_MAX_LENGTH) {
-    content += '...';
-  }
 
   return {
     id,
     date,
     title,
     tag,
-    content,
+    content: getPostPreviewDescription(content),
   };
+};
+
+const getPostPreviewDescription = (content: string) => {
+  const POST_PREVIEW_CONTENT_MAX_LENGTH = 200;
+  const MARKDOWN_CODE_BLOCK_REG_EXP_1 = RegExp(/```([\s\S]*?)```/g);
+  const MARKDOWN_CODE_BLOCK_REG_EXP_2 = RegExp(/~~~([\s\S]*?)~~~/g);
+  const MARKDOWN_HEADING_REG_EXP = RegExp(/#{1,6}.+(?=\n)/);
+
+  const preProcessedContent = content
+    .replace(MARKDOWN_HEADING_REG_EXP, '')
+    .replace(MARKDOWN_CODE_BLOCK_REG_EXP_1, '')
+    .replace(MARKDOWN_CODE_BLOCK_REG_EXP_2, '');
+
+  let description = removeMarkdown(preProcessedContent, {
+    useImgAltText: false,
+  }).slice(0, POST_PREVIEW_CONTENT_MAX_LENGTH);
+
+  if (content.length === POST_PREVIEW_CONTENT_MAX_LENGTH) {
+    description += '...';
+  }
+
+  return description;
 };

--- a/src/lib/posts/post.ts
+++ b/src/lib/posts/post.ts
@@ -9,7 +9,6 @@ import { PostDetail, PostPath, PostPreview } from '../../types/post.types';
 import { getMarkdownData } from './markdown';
 
 const MARKDOWN_FILE_EXTENSION_REG_EXP = RegExp(/\.md$/);
-const LINE_BREAK_REG_EXP = RegExp(/\n/g);
 
 export const getAllPostPaths = (): { params: PostPath }[] => {
   const markdownFilePaths = getPostMarkdownFilePaths();
@@ -33,12 +32,17 @@ export const getPostDetail = async (
   directory: string,
   id: string,
 ): Promise<PostDetail> => {
+  const LINE_BREAK_REG_EXP = RegExp(/\n/g);
+
   const {
     matterResult: { data, content },
     contentHtml,
   } = await getMarkdownData(directory, id);
 
-  const description = removeMarkdown(content).replace(LINE_BREAK_REG_EXP, '');
+  const description = getPostPreviewDescription(content).replace(
+    LINE_BREAK_REG_EXP,
+    '',
+  );
   const { title, date, tag, ...rest } = data;
 
   return {


### PR DESCRIPTION
## 변경사항
- 포스트 리스트 프리뷰 텍스트 일부 수정
  - removeMarkdown 호출 전에 텍스트 slice 하지 않도록 변경
  - 프리뷰 텍스트 가져오는 로직 `getPostPreviewDescription` 함수로 추출
- 포스트 디테일 페이지의 meta tag에 preview description 텍스트 적용