### PR TITLE
fix: robots meta tag's noindex

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,19 @@ export const metadata: Metadata = {
   formatDetection: { telephone: false },
   twitter: { card: 'summary' },
   themeColor: tailwindTheme.colors.neutral[900],
+  robots: {
+    index: true,
+    follow: true,
+    nocache: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      noimageindex: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
   openGraph: generateOpenGraphMetaData({
     title: {
       template: `%s${PAGE_TITLE_SUFFIX}`,


### PR DESCRIPTION
https://github.com/vercel/next.js/issues/58615

`useSearchParams`를 사용하면 robots 메타 태그에 `noindex` 값이 설정되는 이슈 수정