### PR TITLE
fix: apply priority to MarkdownView's Image

### DIFF
--- a/src/components/posts/MarkdownView.tsx
+++ b/src/components/posts/MarkdownView.tsx
@@ -60,6 +60,7 @@ export default function MarkdownView({
                 alt={props.alt ?? ''}
                 width={imageSize?.width ?? 700}
                 height={imageSize?.height ?? 400}
+                priority
               />
             ) : (
               // eslint-disable-next-line @next/next/no-img-element


### PR DESCRIPTION
Reference: https://github.com/vercel/next.js/discussions/20991