### PR TITLE
refactor: remove manual memoization for React Compiler

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/features/post/ui/TableOfContents.tsx
+++ b/src/features/post/ui/TableOfContents.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useRef } from 'react';
+import { useRef } from 'react';
 
 import { useDetectPageScrolling } from '@src/shared';
 
@@ -22,10 +22,10 @@ const TableOfContents = ({ targetElement }: TableOfContentsProps) => {
     pageScrolling,
   });
 
-  const handleItemClick = useCallback((id: string) => {
+  const handleItemClick = (id: string) => {
     const heading = document.getElementById(id);
     heading?.scrollIntoView({ behavior: 'smooth' });
-  }, []);
+  };
 
   return (
     <aside className="absolute left-full">
@@ -44,4 +44,4 @@ const TableOfContents = ({ targetElement }: TableOfContentsProps) => {
   );
 };
 
-export default memo(TableOfContents);
+export default TableOfContents;

--- a/src/features/post/ui/TableOfContentsItem.tsx
+++ b/src/features/post/ui/TableOfContentsItem.tsx
@@ -1,5 +1,3 @@
-import { useCallback } from 'react';
-
 import clsx from 'clsx';
 import * as m from 'motion/react-m';
 
@@ -24,10 +22,8 @@ const TableOfContentsItem = ({
 }: TableOfContentsItemProps) => {
   const { id, title } = heading;
 
-  const attachRef = useCallback(
-    (element: HTMLButtonElement | null) => registerChildRef(element, id),
-    [id, registerChildRef],
-  );
+  const attachRef = (element: HTMLButtonElement | null) =>
+    registerChildRef(element, id);
 
   return (
     <m.li

--- a/src/features/post/ui/TableOfContentsList.tsx
+++ b/src/features/post/ui/TableOfContentsList.tsx
@@ -1,5 +1,3 @@
-import { memo } from 'react';
-
 import TableOfContentsItem from './TableOfContentsItem';
 import { TableOfContentHeading } from '../hooks/useTableOfContents';
 
@@ -11,7 +9,7 @@ interface TableOfContentsListProps {
   level?: number;
 }
 
-export default memo(function TableOfContentsList({
+export default function TableOfContentsList({
   activeId,
   headings,
   onItemClick,
@@ -42,4 +40,4 @@ export default memo(function TableOfContentsList({
       ))}
     </ul>
   );
-});
+}

--- a/src/features/post/ui/TableOfContentsList.tsx
+++ b/src/features/post/ui/TableOfContentsList.tsx
@@ -9,13 +9,13 @@ interface TableOfContentsListProps {
   level?: number;
 }
 
-export default function TableOfContentsList({
+const TableOfContentsList = ({
   activeId,
   headings,
   onItemClick,
   registerChildRef,
   level = 0,
-}: TableOfContentsListProps) {
+}: TableOfContentsListProps) => {
   return (
     <ul style={{ marginLeft: level ? `${level * 0.75}rem` : 0 }}>
       {headings.map((heading) => (
@@ -40,4 +40,6 @@ export default function TableOfContentsList({
       ))}
     </ul>
   );
-}
+};
+
+export default TableOfContentsList;

--- a/src/features/tag/ui/TagButton.tsx
+++ b/src/features/tag/ui/TagButton.tsx
@@ -1,5 +1,3 @@
-import { memo, useCallback } from 'react';
-
 import clsx from 'clsx';
 
 interface TagButtonProps {
@@ -15,10 +13,8 @@ const TagButton = ({
   registerChildRef,
   tag,
 }: TagButtonProps) => {
-  const attachRef = useCallback(
-    (element: HTMLButtonElement | null) => registerChildRef(element, tag),
-    [registerChildRef, tag],
-  );
+  const attachRef = (element: HTMLButtonElement | null) =>
+    registerChildRef(element, tag);
 
   return (
     <button
@@ -39,4 +35,4 @@ const TagButton = ({
   );
 };
 
-export default memo(TagButton);
+export default TagButton;

--- a/src/shared/ui/Footer.tsx
+++ b/src/shared/ui/Footer.tsx
@@ -1,5 +1,3 @@
-import { memo } from 'react';
-
 const Footer = () => (
   <footer className="flex justify-center pb-3 text-sm main-container">
     <p>
@@ -14,4 +12,4 @@ const Footer = () => (
   </footer>
 );
 
-export default memo(Footer);
+export default Footer;

--- a/src/shared/ui/Logo.tsx
+++ b/src/shared/ui/Logo.tsx
@@ -1,5 +1,3 @@
-import { memo } from 'react';
-
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -11,4 +9,4 @@ const Logo = () => (
   </Link>
 );
 
-export default memo(Logo);
+export default Logo;

--- a/src/shared/ui/ProfileCard.tsx
+++ b/src/shared/ui/ProfileCard.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React from 'react';
 
 import Image from 'next/image';
 
@@ -46,4 +46,4 @@ const ProfileCard = () => {
   );
 };
 
-export default memo(ProfileCard);
+export default ProfileCard;

--- a/src/shared/ui/ProfileCard.tsx
+++ b/src/shared/ui/ProfileCard.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Image from 'next/image';
 
 import GithubIcon from '@src/shared/assets/svgs/github.svg';

--- a/src/widgets/base/ui/Header.tsx
+++ b/src/widgets/base/ui/Header.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { memo } from 'react';
-
 import * as m from 'motion/react-m';
 
 import { Logo, DarkModeButton } from '@src/shared';
@@ -20,4 +18,4 @@ const Header = () => {
   );
 };
 
-export default memo(Header);
+export default Header;

--- a/src/widgets/post/ui/PostList.tsx
+++ b/src/widgets/post/ui/PostList.tsx
@@ -45,7 +45,7 @@ const PostList = ({ postPreviews }: PostListProps) => {
       (postPreview) =>
         selectedTag === Tag.all || postPreview.tag === selectedTag,
     )
-    .splice(0, postPage * POST_COUNT_BY_PAGE);
+    .slice(0, postPage * POST_COUNT_BY_PAGE);
 
   return (
     <ul>

--- a/src/widgets/post/ui/PostList.tsx
+++ b/src/widgets/post/ui/PostList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useAtom } from 'jotai';
 
@@ -32,10 +32,7 @@ const PostList = ({ postPreviews }: PostListProps) => {
     [selectedTag, setPostPage],
   );
 
-  const handleIntersect = useCallback(
-    () => setPostPage((prev) => prev + 1),
-    [setPostPage],
-  );
+  const handleIntersect = () => setPostPage((prev) => prev + 1);
 
   useScrollObserver({
     enabled: postPreviews.length > POST_COUNT_BY_PAGE * postPage,
@@ -43,16 +40,12 @@ const PostList = ({ postPreviews }: PostListProps) => {
     targetRef: scrollRef,
   });
 
-  const filteredPostPreviews = useMemo(
-    () =>
-      postPreviews
-        .filter(
-          (postPreview) =>
-            selectedTag === Tag.all || postPreview.tag === selectedTag,
-        )
-        .splice(0, postPage * POST_COUNT_BY_PAGE),
-    [postPreviews, selectedTag, postPage],
-  );
+  const filteredPostPreviews = postPreviews
+    .filter(
+      (postPreview) =>
+        selectedTag === Tag.all || postPreview.tag === selectedTag,
+    )
+    .splice(0, postPage * POST_COUNT_BY_PAGE);
 
   return (
     <ul>

--- a/src/widgets/post/ui/PostListItem.tsx
+++ b/src/widgets/post/ui/PostListItem.tsx
@@ -1,5 +1,3 @@
-import { memo } from 'react';
-
 import Link from 'next/link';
 
 import * as m from 'motion/react-m';
@@ -39,4 +37,4 @@ const PostListItem = ({ postPreview }: PostListItemProps) => {
   );
 };
 
-export default memo(PostListItem);
+export default PostListItem;


### PR DESCRIPTION
## Summary
This PR removes manual memoization (`React.memo`, `useCallback`, `useMemo`) as the project has enabled React Compiler.

## Changes
- Removed `React.memo` from UI components.
- Removed unnecessary `useCallback` and `useMemo` hooks.
- Simplified code in `PostList`, `TagButton`, `TableOfContents`, etc.

## Verification
- Verified `reactCompiler: true` in `next.config.js`.
- Ran `pnpm lint` to ensure no linting errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified multiple UI components by removing memoization and streamlining callback/handler usage to reduce complexity.
* **Chore**
  * Updated Next.js route type configuration to point to the revised generated typings location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->