### PR TITLE
fix(home): resolve Next image quality and SSR errors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,7 @@ const defaultConfig = {
   images: {
     formats: ['image/avif', 'image/webp'],
     deviceSizes: [480, 768, 1024, 1280],
+    qualities: [100, 75],
   },
   webpack(config) {
     config.module.rules.push({

--- a/src/(pages)/home/HomePage/ui/HomePage.tsx
+++ b/src/(pages)/home/HomePage/ui/HomePage.tsx
@@ -1,9 +1,11 @@
 import { Suspense } from 'react';
 
 import { PostPreview } from '@src/features/post/types';
-import { TagSelector, TagSelectorSkeleton } from '@src/features/tag';
-import { DragScrollContainer, ProfileCard } from '@src/shared/ui';
+import { TagSelectorSkeleton } from '@src/features/tag';
+import { ProfileCard } from '@src/shared/ui';
 import { PostList } from '@src/widgets/post';
+
+import HomeTagSelector from './HomeTagSelector';
 
 interface HomePageProps {
   postPreviews: PostPreview[];
@@ -17,9 +19,7 @@ const HomePage = ({ postPreviews, tags }: HomePageProps) => {
         <ProfileCard />
       </div>
       <Suspense fallback={<TagSelectorSkeleton />}>
-        <DragScrollContainer>
-          <TagSelector tags={tags} />
-        </DragScrollContainer>
+        <HomeTagSelector tags={tags} />
       </Suspense>
       <PostList postPreviews={postPreviews} />
     </div>

--- a/src/(pages)/home/HomePage/ui/HomeTagSelector.tsx
+++ b/src/(pages)/home/HomePage/ui/HomeTagSelector.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { TagSelector } from '@src/features/tag';
+import { DragScrollContainer } from '@src/shared/ui';
+
+interface HomeTagSelectorProps {
+  tags: string[];
+}
+
+const HomeTagSelector = ({ tags }: HomeTagSelectorProps) => (
+  <DragScrollContainer>
+    <TagSelector tags={tags} />
+  </DragScrollContainer>
+);
+
+export default HomeTagSelector;


### PR DESCRIPTION
## Summary
- configure Next image qualities to allow existing quality={100} image usage
- move the home tag selector composition into a client component to avoid SSR errors from cloning a client child

## Verification
- pnpm lint
- pnpm exec tsc --noEmit
- fetched local home route and confirmed the embedded React SSR error template is gone