### PR TITLE
Enhance article SEO metadata

### DIFF
--- a/src/app/metadataBase.ts
+++ b/src/app/metadataBase.ts
@@ -4,19 +4,25 @@ import ogTagImage from '@src/shared/assets/images/og_tag_image.png';
 import { DOMAIN_URL } from '@src/shared';
 
 export const generateOpenGraphMetaData = ({
+  imagePath,
   path = '',
   ...rest
 }: {
+  imagePath?: string;
   path?: string;
 } & OpenGraph): OpenGraph => {
+  const images = imagePath
+    ? { url: `${DOMAIN_URL}${imagePath}` }
+    : {
+        url: `${DOMAIN_URL}${ogTagImage.src}`,
+        width: ogTagImage.width,
+        height: ogTagImage.height,
+      };
+
   return {
     type: 'website',
     url: `${DOMAIN_URL}${path}`,
-    images: {
-      url: `${DOMAIN_URL}${ogTagImage.src}`,
-      width: ogTagImage.width,
-      height: ogTagImage.height,
-    },
+    images,
     ...rest,
   };
 };

--- a/src/app/posts/[subdirectory]/[id]/page.tsx
+++ b/src/app/posts/[subdirectory]/[id]/page.tsx
@@ -10,6 +10,8 @@ import {
   getPostImageSizes,
   getAllPostPaths,
 } from '@src/features/post/server';
+import { PROFILE } from '@src/shared/constants/profile';
+import { DOMAIN_URL } from '@src/shared/constants/server';
 
 export async function generateStaticParams() {
   const paths = await getAllPostPaths();
@@ -29,16 +31,24 @@ export async function generateMetadata(props: {
       id,
     );
 
-    const { title, description } = postDetail;
+    const { date, description, ogImagePath, tag, title } = postDetail;
+    const path = `/posts/${subdirectory}/${id}`;
 
     return {
       title,
       description,
+      alternates: {
+        canonical: `${DOMAIN_URL}${path}`,
+      },
       openGraph: generateOpenGraphMetaData({
         type: 'article',
         title,
         description,
-        path: `/posts/${subdirectory}/${id}`,
+        path,
+        imagePath: ogImagePath,
+        publishedTime: date,
+        authors: [PROFILE.name],
+        tags: [tag],
       }),
     };
   } catch (e) {


### PR DESCRIPTION
## Summary
- add canonical URLs and article metadata to post pages
- use per-post OG images when frontmatter provides ogImagePath
- keep Twitter metadata implicit via Next.js Open Graph fallback

## Validation
- git diff --check
- pnpm lint