### PR TITLE
Tune post meta description length

### DIFF
--- a/src/features/post/lib/index.ts
+++ b/src/features/post/lib/index.ts
@@ -1,7 +1,7 @@
+export {
+  getPostMetaDescription,
+  getPostPreviewDescription,
+} from './postDescription';
 export { getPostDetail } from './postDetail';
 export { getPostImageSizes } from './postImage';
-export {
-  getAllPostPaths,
-  getPostPreviewDescription,
-  getSortedPostPreviews,
-} from './postList';
+export { getAllPostPaths, getSortedPostPreviews } from './postList';

--- a/src/features/post/lib/postDescription.ts
+++ b/src/features/post/lib/postDescription.ts
@@ -1,0 +1,64 @@
+import RemoveMarkdown from 'remove-markdown';
+
+export const getPostPreviewDescription = (content: string) => {
+  const POST_PREVIEW_CONTENT_MAX_LENGTH = 200;
+  return getPostDescription(content, {
+    maxLength: POST_PREVIEW_CONTENT_MAX_LENGTH,
+    shouldTrim: false,
+    shouldReserveEllipsisLength: false,
+  });
+};
+
+export const getPostMetaDescription = (content: string) => {
+  const POST_META_DESCRIPTION_MAX_LENGTH = 90;
+  return getPostDescription(content, {
+    maxLength: POST_META_DESCRIPTION_MAX_LENGTH,
+    shouldTrim: true,
+    shouldReserveEllipsisLength: true,
+  });
+};
+
+interface GetPostDescriptionOptions {
+  maxLength: number;
+  shouldReserveEllipsisLength: boolean;
+  shouldTrim: boolean;
+}
+
+const getPostDescription = (
+  content: string,
+  {
+    maxLength,
+    shouldReserveEllipsisLength,
+    shouldTrim,
+  }: GetPostDescriptionOptions,
+) => {
+  const MARKDOWN_CODE_BLOCK_REG_EXP_1 = RegExp(/```([\s\S]*?)```/g);
+  const MARKDOWN_CODE_BLOCK_REG_EXP_2 = RegExp(/~~~([\s\S]*?)~~~/g);
+  const MARKDOWN_HEADING_REG_EXP = RegExp(/#{1,6}.+(?=\n)/);
+
+  const preProcessedContent = content
+    .replace(MARKDOWN_HEADING_REG_EXP, '')
+    .replace(MARKDOWN_CODE_BLOCK_REG_EXP_1, '')
+    .replace(MARKDOWN_CODE_BLOCK_REG_EXP_2, '');
+
+  let description = RemoveMarkdown(preProcessedContent, {
+    useImgAltText: false,
+  });
+
+  if (shouldTrim) {
+    description = description.trim();
+  }
+
+  const ELLIPSIS = '...';
+  const descriptionMaxLength = shouldReserveEllipsisLength
+    ? maxLength - ELLIPSIS.length
+    : maxLength;
+
+  description = description.slice(0, descriptionMaxLength);
+
+  if (content.length >= maxLength) {
+    description += ELLIPSIS;
+  }
+
+  return description;
+};

--- a/src/features/post/lib/postDetail.ts
+++ b/src/features/post/lib/postDetail.ts
@@ -2,8 +2,8 @@ import { notFound } from 'next/navigation';
 
 import { PostDetail } from '@src/features/post/client';
 
+import { getPostMetaDescription } from './postDescription';
 import { getMarkdownData } from './markdown';
-import { getPostPreviewDescription } from './postList';
 
 export const getPostDetail = async (
   directory: string,
@@ -17,7 +17,7 @@ export const getPostDetail = async (
       contentHtml,
     } = await getMarkdownData(directory, id);
 
-    const description = getPostPreviewDescription(content).replace(
+    const description = getPostMetaDescription(content).replace(
       LINE_BREAK_REG_EXP,
       '',
     );

--- a/src/features/post/lib/postList.ts
+++ b/src/features/post/lib/postList.ts
@@ -2,10 +2,11 @@ import fs from 'fs';
 import path from 'path';
 
 import matter from 'gray-matter';
-import RemoveMarkdown from 'remove-markdown';
 
 import { POST_DIRECTORY } from '@src/features/post/constants/directories';
 import { PostPath, PostPreview } from '@src/features/post/types/post.types';
+
+import { getPostPreviewDescription } from './postDescription';
 
 export const getAllPostPaths = async (): Promise<{ params: PostPath }[]> => {
   const MARKDOWN_FILE_EXTENSION_REG_EXP = RegExp(/\.md$/);
@@ -71,26 +72,4 @@ const getPostPreview = async (fileName: string): Promise<PostPreview> => {
     tag,
     content: getPostPreviewDescription(content),
   };
-};
-
-export const getPostPreviewDescription = (content: string) => {
-  const POST_PREVIEW_CONTENT_MAX_LENGTH = 200;
-  const MARKDOWN_CODE_BLOCK_REG_EXP_1 = RegExp(/```([\s\S]*?)```/g);
-  const MARKDOWN_CODE_BLOCK_REG_EXP_2 = RegExp(/~~~([\s\S]*?)~~~/g);
-  const MARKDOWN_HEADING_REG_EXP = RegExp(/#{1,6}.+(?=\n)/);
-
-  const preProcessedContent = content
-    .replace(MARKDOWN_HEADING_REG_EXP, '')
-    .replace(MARKDOWN_CODE_BLOCK_REG_EXP_1, '')
-    .replace(MARKDOWN_CODE_BLOCK_REG_EXP_2, '');
-
-  let description = RemoveMarkdown(preProcessedContent, {
-    useImgAltText: false,
-  }).slice(0, POST_PREVIEW_CONTENT_MAX_LENGTH);
-
-  if (content.length >= POST_PREVIEW_CONTENT_MAX_LENGTH) {
-    description += '...';
-  }
-
-  return description;
 };


### PR DESCRIPTION
## Summary
- split post description extraction into a dedicated helper
- keep post preview descriptions at the existing 200-character behavior
- use a 90-character limit for SEO meta descriptions

## Validation
- git diff --check
- pnpm lint
- pnpm exec tsc --noEmit