### PR TITLE
feat(seo): add JSON-LD structured data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
 import { getSortedPostPreviews } from '@src/features/post/server';
 import { Tag } from '@src/features/tag';
+import { getSiteJsonLd, serializeJsonLd } from '@src/shared/utils';
 import HomePage from '@src/(pages)/home/HomePage/ui/HomePage';
 
 export default async function Page() {
   const postPreviews = await getSortedPostPreviews();
+  const siteJsonLd = getSiteJsonLd();
 
   const tags = [
     Tag.all,
@@ -12,5 +14,13 @@ export default async function Page() {
     ).sort(),
   ];
 
-  return <HomePage postPreviews={postPreviews} tags={tags} />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(siteJsonLd) }}
+      />
+      <HomePage postPreviews={postPreviews} tags={tags} />
+    </>
+  );
 }

--- a/src/app/posts/[subdirectory]/[id]/page.tsx
+++ b/src/app/posts/[subdirectory]/[id]/page.tsx
@@ -8,10 +8,12 @@ import { POST_DIRECTORY } from '@src/features/post/constants/directories';
 import {
   getPostDetail,
   getPostImageSizes,
+  getPostJsonLd,
   getAllPostPaths,
 } from '@src/features/post/server';
 import { PROFILE } from '@src/shared/constants/profile';
 import { DOMAIN_URL } from '@src/shared/constants/server';
+import { serializeJsonLd } from '@src/shared/utils';
 
 export async function generateStaticParams() {
   const paths = await getAllPostPaths();
@@ -68,8 +70,18 @@ export default async function PostDetailPage(props: {
     `${POST_DIRECTORY}/${subdirectory}`,
     id,
   );
+  const path = `/posts/${subdirectory}/${id}`;
+  const postJsonLd = getPostJsonLd({ path, postDetail });
 
   const imageSizes = getPostImageSizes(postDetail.contentHtml);
 
-  return <PostPage postDetail={postDetail} imageSizes={imageSizes} />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(postJsonLd) }}
+      />
+      <PostPage postDetail={postDetail} imageSizes={imageSizes} />
+    </>
+  );
 }

--- a/src/features/post/lib/index.ts
+++ b/src/features/post/lib/index.ts
@@ -4,4 +4,5 @@ export {
 } from './postDescription';
 export { getPostDetail } from './postDetail';
 export { getPostImageSizes } from './postImage';
+export { getPostJsonLd } from './postJsonLd';
 export { getAllPostPaths, getSortedPostPreviews } from './postList';

--- a/src/features/post/lib/postJsonLd.ts
+++ b/src/features/post/lib/postJsonLd.ts
@@ -1,0 +1,72 @@
+import ogTagImage from '@src/shared/assets/images/og_tag_image.png';
+import { DOMAIN_URL, PROFILE } from '@src/shared/constants';
+
+import { PostDetail } from '../types';
+
+interface JsonLdPerson {
+  '@type': 'Person';
+  name: string;
+  url: string;
+}
+
+interface JsonLdWebPage {
+  '@type': 'WebPage';
+  '@id': string;
+}
+
+interface PostJsonLd {
+  '@context': 'https://schema.org';
+  '@type': 'BlogPosting';
+  headline: string;
+  description: string;
+  datePublished: string;
+  dateModified: string;
+  author: JsonLdPerson;
+  url: string;
+  mainEntityOfPage: JsonLdWebPage;
+  image: string[];
+  keywords: string[];
+}
+
+const toAbsoluteUrl = (pathOrUrl: string) => {
+  if (pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://')) {
+    return pathOrUrl;
+  }
+
+  const path = pathOrUrl.startsWith('/') ? pathOrUrl : `/${pathOrUrl}`;
+
+  return `${DOMAIN_URL}${path}`;
+};
+
+export const getPostJsonLd = ({
+  path,
+  postDetail,
+}: {
+  path: string;
+  postDetail: PostDetail;
+}): PostJsonLd => {
+  const { date, description, ogImagePath, tag, title } = postDetail;
+  const url = toAbsoluteUrl(path);
+  const imageUrl = toAbsoluteUrl(ogImagePath ?? ogTagImage.src);
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: title,
+    description,
+    datePublished: date,
+    dateModified: date,
+    author: {
+      '@type': 'Person',
+      name: PROFILE.name,
+      url: PROFILE.social.github,
+    },
+    url,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': url,
+    },
+    image: [imageUrl],
+    keywords: [tag],
+  };
+};

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,4 +1,6 @@
 export { findElementsByTags } from './elementUtils';
 export { isServer } from './isServer';
+export { serializeJsonLd } from './jsonLd';
 export { mergeRefs } from './refUtils';
+export { getSiteJsonLd } from './siteJsonLd';
 export { default as StorageUtil, StorageKeys } from './storage';

--- a/src/shared/utils/jsonLd.ts
+++ b/src/shared/utils/jsonLd.ts
@@ -1,0 +1,2 @@
+export const serializeJsonLd = (jsonLd: unknown) =>
+  JSON.stringify(jsonLd).replace(/</g, '\\u003c');

--- a/src/shared/utils/siteJsonLd.ts
+++ b/src/shared/utils/siteJsonLd.ts
@@ -1,0 +1,43 @@
+import { DOMAIN_URL, PROFILE } from '@src/shared/constants';
+
+interface SiteJsonLdGraphItem {
+  '@type': 'WebSite' | 'Person';
+  '@id': string;
+  name: string;
+  url: string;
+  sameAs?: string[];
+  publisher?: {
+    '@id': string;
+  };
+}
+
+interface SiteJsonLd {
+  '@context': 'https://schema.org';
+  '@graph': SiteJsonLdGraphItem[];
+}
+
+export const getSiteJsonLd = (): SiteJsonLd => {
+  const personId = `${DOMAIN_URL}/#person`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebSite',
+        '@id': `${DOMAIN_URL}/#website`,
+        name: 'KimBiYam.log',
+        url: DOMAIN_URL,
+        publisher: {
+          '@id': personId,
+        },
+      },
+      {
+        '@type': 'Person',
+        '@id': personId,
+        name: PROFILE.name,
+        url: PROFILE.social.github,
+        sameAs: [PROFILE.social.github, PROFILE.social.linkedIn],
+      },
+    ],
+  };
+};


### PR DESCRIPTION
## Summary
- add WebSite and Person JSON-LD to the home page
- add BlogPosting JSON-LD to post detail pages
- share JSON-LD serialization with HTML escaping

## Validation
- git diff --check
- pnpm lint
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured data markup to improve search engine visibility and social media preview cards for the homepage and individual blog posts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->